### PR TITLE
Don't try to publish chart if it already exists

### DIFF
--- a/.github/workflows/publish_chart.yaml
+++ b/.github/workflows/publish_chart.yaml
@@ -24,5 +24,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
our workflows were failing because they were trying to push chart versions that already existed