### PR TITLE
add github lint action for missing charts

### DIFF
--- a/.github/workflows/chatops_chart.yaml
+++ b/.github/workflows/chatops_chart.yaml
@@ -1,0 +1,23 @@
+name: lint chatops Chart
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - ".github/workflows/chatops_chart.yaml"
+      - "charts/chatops/**"
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+      - name: Lint Helm Chart
+        # Note --strict=true != --strict with the former being stricter
+        run: |
+          cp charts/chatops/secret-values.yaml.template /tmp/secret-values.yaml
+          helm dependency update charts/chatops/.
+          helm lint charts/chatops --values charts/chatops/values.yaml --values /tmp/secret-values.yaml --strict=true

--- a/.github/workflows/publish_chart.yaml
+++ b/.github/workflows/publish_chart.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           skip_existing: true
         env:

--- a/.github/workflows/stfc_cloud_openstack_cluster_chart.yaml
+++ b/.github/workflows/stfc_cloud_openstack_cluster_chart.yaml
@@ -1,0 +1,23 @@
+name: lint stfc-cloud-openstack-cluster Chart
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - ".github/workflows/stfc_cloud_openstack_cluster_chart.yaml"
+      - "charts/stfc-cloud-openstack-cluster/**"
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+      - name: Lint Helm Chart
+        # Note --strict=true != --strict with the former being stricter
+        run: |
+          cp charts/stfc-cloud-openstack-cluster/secret-values.yaml.template /tmp/secret-values.yaml
+          helm dependency update charts/stfc-cloud-openstack-cluster/.
+          helm lint charts/stfc-cloud-openstack-cluster --values charts/stfc-cloud-openstack-cluster/values.yaml --values /tmp/secret-values.yaml --values charts/stfc-cloud-openstack-cluster/flavors.yaml --values charts/stfc-cloud-openstack-cluster/user-values.yaml --strict=true

--- a/charts/chatops/secret-values.yaml.template
+++ b/charts/chatops/secret-values.yaml.template
@@ -2,10 +2,10 @@
 # holds slack and github auth tokens
 # holds mappings for devops team slack and github usernames
 secrets:
-  slackBotToken: <>
-  slackAppToken: <>
-  githubToken: <>
+  slackBotToken: foo
+  slackAppToken: bar
+  githubToken: baz
   users:
     - realName: foo
-      githubName: <>
-      slackID: <>
+      githubName: bar
+      slackID: baz

--- a/charts/stfc-cloud-openstack-cluster/secret-values.yaml.template
+++ b/charts/stfc-cloud-openstack-cluster/secret-values.yaml.template
@@ -15,13 +15,13 @@ openstack-cluster:
     openstack:
       auth:
         auth_url:
-        application_credential_id: 
-        application_credential_secret: 
+        application_credential_id: "foo" # change this
+        application_credential_secret: "bar" # change this
 
         # project id needs to be explicitly added
-        project_id: 
+        project_id: "baz" #change this
       
-      region_name:   
+      region_name: "region" 
       interface: "public"
       identity_api_version: 3
       auth_type: "v3applicationcredential"


### PR DESCRIPTION
add github actions to lint chatops and stfc-cloud-openstack-cluster charts. 
This will allow them to actually be published :)  