### PR TITLE
add github action to update helm dependencies

### DIFF
--- a/.github/workflows/publish_chart_from_main.yaml
+++ b/.github/workflows/publish_chart_from_main.yaml
@@ -1,4 +1,4 @@
-name: publish charts
+name: Publish Release-Ready Charts from Main
 on:
   push:
     branches:
@@ -7,7 +7,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    # Run on main branch pushes OR pull requests OR manual triggers
+    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish_dev_chart.yaml
+++ b/.github/workflows/publish_dev_chart.yaml
@@ -1,0 +1,82 @@
+name: Publish a dev chart
+on:
+  workflow_dispatch:
+    inputs:
+      charts:
+        description: "(Optional) Comma-separated list of charts to release dev chart of"
+        type: string
+        required: false
+        default: ""
+
+
+
+jobs:
+  discover-charts:
+    runs-on: ubuntu-latest
+    outputs:
+      chart-names: ${{ steps.set-charts.outputs.chart-names }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Find charts
+        id: set-charts
+        run: |
+          CHARTS_JSON=$(echo "${{ github.event.inputs.charts }}" | tr ',' '\n' | jq -R -s -c 'split("\n")[:-1]')
+          echo "chart-names=$CHARTS_JSON" >> $GITHUB_OUTPUT
+
+  bump-charts:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chart: ${{ fromJson(needs.discover-charts.outputs.chart-names) }}
+    # Run on main branch pushes OR pull requests OR manual triggers
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+      
+      - name: "Set alpha chart version"
+        if: ${{ steps.deps-update.outputs.update-type != 'none' }}
+        id: bump-version
+        run: |
+          CHART_YAML="charts/${{matrix.chart}}/Chart.yaml"
+          # Get current version
+          CURRENT_VERSION=$(yq e '.version' "$CHART_YAML")
+          # Split version into major, minor, patch, and ignore any extra parts
+          IFS='.' read -r major minor patch _ <<< "$CURRENT_VERSION"
+          
+          # Get the latest commit short hash
+          GIT_COMMIT_TAG=$(git rev-parse --short HEAD)
+          
+          # Update Chart.yaml with new version
+          # Adding alpha.<github commit tag> to set it as alpha chart
+          VERSION=${major}.${minor}.$((patch)).alpha.${GIT_COMMIT_TAG}
+          yq e -i ".version = \"$VERSION\"" "$CHART_YAML"
+          echo version=$VERSION >> $GITHUB_OUTPUT
+
+      - name: Commit changes
+        if: steps.check-changes.outputs.changes_detected == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "bump chart ${{matrix.chart}} to version: ${{ steps.bump-version.outputs.version }}"
+
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          skip_existing: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Add a github action to update helm dependencies on our charts that use subcharts
- taken from https://github.com/camptocamp/helm-dependency-update-action
