### PR TITLE
tweaks to chart for argocd

### DIFF
--- a/charts/stfc-cloud-openstack-cluster/Chart.yaml
+++ b/charts/stfc-cloud-openstack-cluster/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 description: A Helm chart to deploy a compliant K8s cluster (using CAPI) on the STFC Cloud
 name: stfc-cloud-openstack-cluster
 type: application
-version: 1.4.1
+version: 1.4.2

--- a/charts/stfc-cloud-openstack-cluster/addons.yaml
+++ b/charts/stfc-cloud-openstack-cluster/addons.yaml
@@ -7,15 +7,6 @@ openstack-cluster:
     # For configuration values 
     monitoring:
       enabled: false
-      
-      # for setting up out-of-the-box lgging
-      loki-stack:
-        # set to true to install
-        enabled: false 
-        release:
-          values: {}
-            # for values see - https://github.com/grafana/helm-charts/tree/main/charts/loki-stack
-      
 
       kubePrometheusStack:
         # set to true to install

--- a/charts/stfc-cloud-openstack-cluster/values.yaml
+++ b/charts/stfc-cloud-openstack-cluster/values.yaml
@@ -50,6 +50,11 @@ openstack-cluster:
     # The flavor to use for control plane machines
     machineFlavor: l3.nano
 
+    # chart defaults cause OutofSync issues in argocd as it doesn't include "0m0s"
+    remediationStrategy:
+      retryPeriod: 20m0s
+      minHealthyPeriod: 1h0m0s
+
   # Defaults for node groups
   nodeGroupDefaults:
     # Indicates if the node group should be autoscaled
@@ -96,6 +101,10 @@ openstack-cluster:
     # and includes Loki which is required for central logging as per UKRI policy
     monitoring:
       enabled: true
+      # disable loki-stack by default 
+      # we'll setup our own log collection
+      lokiStack:
+        enabled: false
     # set availabilty zone as upstream uses nova by default
     openstack:
       csiCinder:


### PR DESCRIPTION
- add "0m0s" to control plane remediation strategy values to prevent argocd out-of-sync issues

- disable loki-stack and don't advertise it to promote our own logging solution in future
