### PR TITLE
MAINT: Bumping the rabbit consumer version

### DIFF
--- a/charts/stfc-cloud-rabbit-consumer/Chart.yaml
+++ b/charts/stfc-cloud-rabbit-consumer/Chart.yaml
@@ -12,4 +12,4 @@ version: 1.8.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.1.0"
+appVersion: "v3.1.2"

--- a/charts/stfc-cloud-rabbit-consumer/Chart.yaml
+++ b/charts/stfc-cloud-rabbit-consumer/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Bumping the version following the change to the message_consumer.py script