### PR TITLE
Use default dpkg options for configuration changes

### DIFF
--- a/charts/stfc-cloud-openstack-cluster/scripts/bootstrap.sh
+++ b/charts/stfc-cloud-openstack-cluster/scripts/bootstrap.sh
@@ -34,7 +34,10 @@ echo "Updating system to apply latest security patches..."
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update -qq
 # Shut apt up, since it just blows up the logs
-sudo apt-get upgrade -y -qq > /dev/null
+# On dialogues about config file updates, keep current config file and use default choices
+sudo apt-get -o Dpkg::Options::="--force-confold" \
+             -o Dpkg::Options::="--force-confdef" \
+             -y -qq upgrade > /dev/null
 
 echo "Installing required tools..."
 sudo apt-get install -y snapd


### PR DESCRIPTION
I had an issue with the bootstrap script where SSHD had upgraded and changed its configuration files. Debian wanted a choice on whether to use current or package container config.

Since we're using noninteractive, it couldn't get a choice. So it got stuck in a non-working state without ssh access.

We should consider removing non-interactive altogether, I doubt `bootstrap.sh` will be ran headless.

 But this will avoid things ending up in non-working states for now.