### PR TITLE
Add PR linting for Harbor

### DIFF
--- a/.github/workflows/harbor_chart.yaml
+++ b/.github/workflows/harbor_chart.yaml
@@ -1,0 +1,25 @@
+name: lint stfc-cloud-harbor chart
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - ".github/workflows/harbor_chart.yaml"
+      - "charts/stfc-cloud-harbor/**"
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.18.3
+      - name: Lint Helm Chart
+        # Note --strict=true != --strict with the former being stricter
+        run: |
+          cp charts/stfc-cloud-harbor/secret-values.yaml.template /tmp/secret-values.yaml
+          helm dependency update charts/stfc-cloud-harbor/.
+          helm lint charts/stfc-cloud-harbor --values charts/stfc-cloud-harbor/values.yaml --values /tmp/secret-values.yaml --strict=true


### PR DESCRIPTION
Add missing GH workflow for automatic linting of our Harbor chart upon PR, ~~and fix a few typos.~~

~~There are more typos to fix (i.e. is bucket needed in secret-values? Why are the access/secret keys under harbor.persistance.s3 in values.yaml, should this be in secrets?)~~

~~But I don't know enough about the chart for those, and this is just a rough first chart.~~