### PR TITLE
BUG: custom roles do not allow custom admin password

### DIFF
--- a/charts/stfc-cloud-opensearch/Chart.yaml
+++ b/charts/stfc-cloud-opensearch/Chart.yaml
@@ -9,4 +9,4 @@ dependencies:
 description: A Helm chart to deploy an opinionated opensearch cluster with IRIS-IAM integration
 name: stfc-cloud-opensearch
 type: application
-version: 2.0.0
+version: 2.0.1

--- a/charts/stfc-cloud-opensearch/README.md
+++ b/charts/stfc-cloud-opensearch/README.md
@@ -22,7 +22,6 @@ For Opensearch and Opensearch Dashboards to be accessible outside the cluster - 
 
 # Installation
 
-
 ## Setup Secrets
 
 To use this chart, you need to provide secret values. Follow these steps:
@@ -79,6 +78,11 @@ helm repo update
 helm install opensearch cloud-charts/stfc-cloud-opensearch -n opensearch-system --create-namespace -f secret-values.yaml
 ```
 
+## 3. Change the admin password
+
+By default the admin password is `admin` once you deploy opensearch be sure to change the password via the UI or making a post request to the endpoint.
+
+You will want to change the dashboard user `kibanaserver` password, which has default password `kibanaserver` and is the way opensearch dashboards accesses the opensearch nodes
 
 # Configuration
 

--- a/charts/stfc-cloud-opensearch/secret-values.yaml.template
+++ b/charts/stfc-cloud-opensearch/secret-values.yaml.template
@@ -2,12 +2,6 @@
 # copy this file into /tmp/secrets-values.yaml and modify it with secrets
 # then run helm install my-opensearch charts/opensearch -f /tmp/secrets-values.yaml from repo root dir
 
-adminCredentials:
-  # Provide username and password for the initial admin user - used to configure and manage the cluster
-  # You must provide the password in plaintext and as a bycrpt hash 
-  username: admin
-  password: admin
-
 # credentials for opensearch users - they will be stored in a secret - 
 userCredentials:
   - username: user1

--- a/charts/stfc-cloud-opensearch/templates/admin-secret.yaml
+++ b/charts/stfc-cloud-opensearch/templates/admin-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ (index .Values "opensearch-cluster").cluster.security.config.adminCredentialsSecret.name }}
-  namespace: {{ .Release.Namespace }}
-type: Opaque
-stringData:
-    username: {{ .Values.adminCredentials.username }}
-    password: {{ .Values.adminCredentials.password }}

--- a/charts/stfc-cloud-opensearch/values.yaml
+++ b/charts/stfc-cloud-opensearch/values.yaml
@@ -5,7 +5,7 @@ opensearch-operator:
 opensearch-cluster:
   cluster:
     # change this to match name of cluster you want
-    name: log-storage
+    name: "opensearch-cluster"
 
     annotations: 
       helm.sh/hook: post-install,post-upgrade
@@ -40,6 +40,7 @@ opensearch-cluster:
       snapshotRepositories: []
     
     dashboards:
+
       enable: true
       tls: 
         enable: true
@@ -75,7 +76,6 @@ opensearch-cluster:
               - opensearch.example.com
 
       dashboards:
-        opensearchCredentialsSecret: opensearch-admin-credentials
 
         annotations:
           nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
@@ -91,11 +91,7 @@ opensearch-cluster:
           - secretName: opensearch-tls
             hosts:
               - opensearch-dashboards.example.com
-        
-    security:
-      config: 
-        adminCredentialsSecret: 
-          name: opensearch-admin-credentials
+      
   
   # define roles here
   # https://opensearch.org/docs/latest/security/configuration/yaml/#rolesyml


### PR DESCRIPTION
there is a current issue with upstream where securityconfig cannot be used in conjunction with crds so we cannot define a custom admin - we must use default admin and change manually once the cluster is setup
