### PR TITLE
BUG: Fix the default container name for logging

### DIFF
--- a/charts/stfc-cloud-rabbit-consumer/Chart.yaml
+++ b/charts/stfc-cloud-rabbit-consumer/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.1
+version: 1.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/stfc-cloud-rabbit-consumer/templates/deployment.yaml
+++ b/charts/stfc-cloud-rabbit-consumer/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Force pod restart on configmap change
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        kubectl.kubernetes.io/default-container: consumer
+        kubectl.kubernetes.io/default-container: consumer-ral-info
       labels:
         app: rabbit-consumer
     spec:


### PR DESCRIPTION
There are now two consumer containers, consumer-ral-info and consumer-ral-error , this means pointing to consumer is invalid and was missed from a previous change