### PR TITLE
DOC: Add longhorn loadbalancer annotation to prevent deleting floating IPs

### DIFF
--- a/charts/stfc-cloud-longhorn/README.md
+++ b/charts/stfc-cloud-longhorn/README.md
@@ -61,7 +61,10 @@ longhorn:
     enabled: false
   service:
     ui:
-        # -- Service type for Longhorn UI. (Options: "ClusterIP", "NodePort", "LoadBalancer", "Rancher-Proxy")
-        type: Loadbalancer
-        loadBalancerIP: 130.246.x.x
+      type: LoadBalancer
+      loadBalancerIP: "{{ longhorn_ip }}"
+      annotations:
+        # Don't delete the floating ip when deleting loadbalancers
+        # prevents errors when deleting clusters, leave as true
+        loadbalancer.openstack.org/keep-floatingip: "true"
 ```


### PR DESCRIPTION
If using a loadbalancer for longhorn, it will try to delete the floating IP when it uninstalls.

Add required annotation to keep the floating IP.