### PR TITLE
update fluentbit servicemonitor url

### DIFF
--- a/charts/stfc-cloud-logging/Chart.yaml
+++ b/charts/stfc-cloud-logging/Chart.yaml
@@ -4,4 +4,4 @@ dependencies:
     repository: https://fluent.github.io/helm-charts
     version: 4.2.0
 name: stfc-cloud-logging
-version: 2.0.0
+version: 2.0.1

--- a/charts/stfc-cloud-logging/values.yaml
+++ b/charts/stfc-cloud-logging/values.yaml
@@ -105,6 +105,7 @@ fluent-operator:
 
     serviceMonitor:
       enable: true
+      path: /metrics
 
     input:
       fluentBitMetrics:


### PR DESCRIPTION
the url changed from default /api/v2/metrics/prometheus to just /metrics - not sure when this change happened (probably moving to v3 -> v4 of fluent operator) - but this clears an alert of TargetDown for fluentbit
