### PR TITLE
Increase quota of Trivy pvc.

### DIFF
--- a/charts/stfc-cloud-harbor/Chart.yaml
+++ b/charts/stfc-cloud-harbor/Chart.yaml
@@ -4,4 +4,4 @@ dependencies:
     repository: https://helm.goharbor.io
     version: 1.19.2
 name: stfc-cloud-harbor
-version: 2.1.4
+version: 2.1.5

--- a/charts/stfc-cloud-harbor/values.yaml
+++ b/charts/stfc-cloud-harbor/values.yaml
@@ -165,7 +165,7 @@ harbor:
         storageClass: ""
         subPath: ""
         accessMode: ReadWriteOnce
-        size: 10Gi
+        size: 50Gi
         annotations: {}
 
     imageChartStorage:


### PR DESCRIPTION
- The pvcs' has filled up due to which container images cannot be scanned for vulnerabilities.